### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install CINC Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
         with:
           channel: stable
           version: '24'

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,4 +11,4 @@ name: conventional-commits
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install CINC Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
         with:
           channel: stable
           version: '24'
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -11,6 +11,6 @@ name: prevent-file-change
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,25 +18,25 @@ service policy mechanism used by `invoke-rc.d` during package installation.
 
 Supported platforms:
 
-- Debian 12+
-- Ubuntu 24.04+
+* Debian 12+
+* Ubuntu 24.04+
 
 ## Package Manager Scope
 
 This cookbook is only useful for packages installed through Debian packaging tools
 that honor `invoke-rc.d` and `/usr/sbin/policy-rc.d`.
 
-- `apt`
-- `dpkg`
+* `apt`
+* `dpkg`
 
 It does not manage service start behavior for RPM-based systems or packages that do
 not consult `invoke-rc.d`.
 
 ## Behavioral Constraints
 
-- The resource suppresses package autostart by installing an executable
+* The resource suppresses package autostart by installing an executable
   `/usr/sbin/policy-rc.d` script that exits `101`.
-- If the script must exist before compile-time package installation, callers should
+* If the script must exist before compile-time package installation, callers should
   declare the resource with `compile_time true`.
-- The delete action removes only scripts created by this cookbook unless
+* The delete action removes only scripts created by this cookbook unless
   `force_delete true` is set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# LIMITATIONS
+# AGENTS.md
+
+## Cookbook Purpose
+
+Provides a custom resource for suppressing Debian package autostart
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Platform Support
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -10,5 +10,5 @@ cookbook 'test', path: './test/cookbooks/test'
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
 
-  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+  named_run_list recipe_name.to_sym, 'recipe[test::' + recipe_name + ']'
 end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'deb_pkg_unautostart'
+
+run_list 'test::default'
+
+cookbook 'deb_pkg_unautostart', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -41,8 +41,12 @@ x-verifiers:
 
 suites:
   - name: default
+    provisioner:
+      named_run_list: default
     run_list: *default_run_list
     verifier: *default_verifier
   - name: remove
+    provisioner:
+      named_run_list: remove
     run_list: *remove_run_list
     verifier: *remove_verifier

--- a/resources/policy_rc_d.rb
+++ b/resources/policy_rc_d.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 unified_mode true
+provides :deb_pkg_unautostart_policy_rc_d
 
 property :path, String, default: '/usr/sbin/policy-rc.d'
 property :owner, String, default: 'root'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list